### PR TITLE
Minor code improvements

### DIFF
--- a/npc/main.lua
+++ b/npc/main.lua
@@ -9,14 +9,11 @@ function CreatePed(gender, gear, features, house, spawnPos)
     Ped.gender = gender
     Ped.house = house
 
-    local time_point = Ped.time_point
-    local movement = time_point.movement
+    local movement = Ped.time_point.movement
     movement.position.x = spawnPos.x
     movement.position.y = spawnPos.y
     movement.position.z = spawnPos.z
     movement.speed = 0
-    time_point.movement = movement
-    Ped.time_point = time_point
 
     local item = GearItem.new()
     local setGear = Ped.gear
@@ -24,7 +21,6 @@ function CreatePed(gender, gear, features, house, spawnPos)
         item.id = v
         setGear:add(item)
     end
-    Ped.gear = setGear
 
     local preset = AvatarPreset.new()
     local presets = Ped.presets
@@ -32,7 +28,6 @@ function CreatePed(gender, gear, features, house, spawnPos)
         preset.name = v
         presets:add(preset)
     end
-    Ped.presets = presets
 
     server.npc_manager:Spawn(Ped)
     table.insert(Peds, Ped)

--- a/player/commands.lua
+++ b/player/commands.lua
@@ -14,7 +14,7 @@ local function findPlayer(target)
 end
 
 registerCommand("kick", function(player, args)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_target))
         return
     end
@@ -24,7 +24,7 @@ registerCommand("kick", function(player, args)
         return
     end
     table.remove(args, 1)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_reason))
         return
     end
@@ -38,7 +38,7 @@ registerCommand("kick", function(player, args)
 end, {"admin", "mod"})
 
 registerCommand("ban", function(player, args)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_target))
         return
     end
@@ -48,7 +48,7 @@ registerCommand("ban", function(player, args)
         return
     end
     table.remove(args, 1)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_reason))
         return
     end
@@ -65,7 +65,7 @@ end, {"admin", "mod"})
 
 registerCommand("getpos", function(player, args)
     local target
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         target = player
     else
         target = findPlayer(args[1])
@@ -78,7 +78,7 @@ registerCommand("getpos", function(player, args)
 end, {"admin", "mod"})
 
 registerCommand({"pm", "dm", "whisper"}, function (player, args)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_target))
         return
     end
@@ -88,7 +88,7 @@ registerCommand({"pm", "dm", "whisper"}, function (player, args)
         return
     end
     table.remove(args, 1)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_message))
         return
     end
@@ -105,7 +105,7 @@ registerCommand({"dc", "quit"}, function (player, args)
 end)
 
 registerCommand("announce", function(player, args)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_message))
         return
     end
@@ -119,13 +119,13 @@ registerCommand("announce", function(player, args)
 end, {"admin", "mod"})
 
 registerCommand({"wl", "whitelist"}, function(player, args)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_function))
         return
     end
     local func = args[1]
     table.remove(args, 1)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_target))
         return
     end
@@ -154,7 +154,7 @@ registerCommand({"wl", "whitelist"}, function(player, args)
 end, {"admin", "mod"})
 
 registerCommand({"setp", "setpermission"}, function(player, args)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_target))
         return
     end
@@ -164,7 +164,7 @@ registerCommand({"setp", "setpermission"}, function(player, args)
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.invalid_target))
         return
     end
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage(string.format(Locale.Core.systemtag, Locale.Commands.provide_function))
         return
     end

--- a/player/emotes.lua
+++ b/player/emotes.lua
@@ -29,7 +29,7 @@ local emotes = {
 }
 
 registerCommand({"e", "emote"}, function (player, args)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:RpcSetAnimation("")
         return
     end

--- a/test_race/commands.lua
+++ b/test_race/commands.lua
@@ -1,5 +1,5 @@
 Exports.player.registerCommand("startrace", function(player, args)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage("Provide a race name!")
         return
     end
@@ -34,7 +34,7 @@ Exports.player.registerCommand("startrace", function(player, args)
 end)
 
 Exports.player.registerCommand("joinrace", function(player, args)
-    if args == {} or args[1] == nil then
+    if #args == 0 or args[1] == nil then
         player:SendSystemMessage("Provide a race name!")
         return
     end


### PR DESCRIPTION
These minor potential improvements target some parts of the code that could help improve readibility, such as removing unnecessary self-assigments (When assigning a table to a variable, what is actually saved is a reference, so any modifications to members of the variable will be reflected in the original table.

The other change is correctly checking if a numerically indexed table is empty. Doing  `table == {}` is actually checking if the references to the tables are the same, not comparing the actual members of the tables. So it will always return false. This method won't work on key-value tables, but from what I saw in the code, the expected shape of the "args" table is an array of command arguments sent in chat by a player, so it should work for these cases.

Please note that I do not have access to HogWarp so I can't test these changes. I'm pretty confident that nothing should break with these changes, functionality should remain the same, but I would still test just in case 😅.

Anyway, last thing, I'm not quite sure about this, so maybe you @BrianxTu could help me understand it. From what I see in the chatcommand module in your fork of the MoM repository, the extension of the string type has a **split** method that you use in the command module to retrieve the list of args. My doubt is that considering the way **split** is defined, it should return a call to gmatch, which in itself returns an iterator function, but in the code in the chatcommand module, the return value is treated as an array of strings, so I'm kind of lost here. I'm probably just looking at a wrong version of the extensions file, but still wanted to understand that part.

Anyway, long message! Cool project you have here, and if I ever get my hands on HogWarp, I'll be sure to use this, and maybe contribute some cool ideas in the future!